### PR TITLE
Convert nav components to pass in context

### DIFF
--- a/addon/components/ef-list-item.js
+++ b/addon/components/ef-list-item.js
@@ -1,4 +1,7 @@
+import Ember from 'ember';
 import Component from 'ember-forge-ui/components/ef-list-item';
+
+const computed = Ember.computed;
 
 /**
  * @module
@@ -13,9 +16,9 @@ export default Component.extend({
   // Attributes
 
   /** @type {String[]} */
-  classNames: [
-    'list-group-item'
-  ]
+  classNameBindings: [
+    'contextualClasses'
+  ],
 
   // -------------------------------------------------------------------------
   // Actions
@@ -25,6 +28,14 @@ export default Component.extend({
 
   // -------------------------------------------------------------------------
   // Properties
+
+  /** @type {String} */
+  contextualClasses: computed('isNav', function() {
+    if (!this.get('isNav')) {
+      return 'list-group-item';
+    }
+    return '';
+  })
 
   // -------------------------------------------------------------------------
   // Observers

--- a/addon/components/ef-list.js
+++ b/addon/components/ef-list.js
@@ -24,18 +24,6 @@ export default Component.extend({
   // Events
 
   /**
-   * init event hook
-   *
-   * Configure the list
-   *
-   * @function
-   * @returns {undefined}
-   */
-  init() {
-    this._super(...arguments);
-  },
-
-  /**
    * didInsertElement event hook
    *
    * Apply correct styling to list

--- a/addon/components/ef-nav.js
+++ b/addon/components/ef-nav.js
@@ -28,7 +28,7 @@ export default Component.extend({
    *
    * @returns {undefined}
    */
-  didInsertElement() {
+  didRender() {
     this._super(...arguments);
 
     this.setListContext();
@@ -61,11 +61,6 @@ export default Component.extend({
     this.$('.list-group')
       .removeClass('list-group')
       .addClass('nav');
-
-    // ef-list-item
-    this.$('.list-group-item')
-      .removeClass('list-group-item')
-      .addClass('nav-item');
   }
 
 });

--- a/app/templates/components/ef-nav.hbs
+++ b/app/templates/components/ef-nav.hbs
@@ -5,6 +5,7 @@
         "ef-list-item"
         active=active
         disabled=disabled
+        isNav=true
       )
     )}}
   {{/ef-list}}


### PR DESCRIPTION
Currently, the nav components (like `ef-nav`) rely on a `didInsertElement` hook to modify classes on child components (like `ef-list-item`) to make them visually compatible with nav styling.

This is problematic because when the child components re-render (i.e. because the `ef-list-item` was clicked on, and needs to add an `active` class), they will re-render with their initial classes (which were removed by the parent `ef-nav`). But - the parent `ef-nav`'s `didInsertElement()` hook does not re-fire (nor does any other lifecycle hook).

This change strips out the direct DOM manipulation of child components in favor of passing in bound context information to the contextual child components. This lets the child components decide how to react, and persist those reactions across re-renders.

This initial pass just adds an `isNav` boolean to the `ef-list-item`, which hides the `.list-group-item` class when true. As the API grows, `isNav` should probably be replaced with a more generic `context` of some kind.
